### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/iamsrinii/dd17fdec-8145-4286-8745-686609200f90/699c1ef9-f1fd-4f70-afc9-3378842c1380/_apis/work/boardbadge/78ea2cdf-7fa2-457b-86cb-d1e4888ebfb8)](https://dev.azure.com/iamsrinii/dd17fdec-8145-4286-8745-686609200f90/_boards/board/t/699c1ef9-f1fd-4f70-afc9-3378842c1380/Microsoft.RequirementCategory)
 # api-tests-python
 
 [![CircleCI](https://circleci.com/gh/pishchalnikov/api-tests-python.svg?style=svg)](https://circleci.com/gh/pishchalnikov/api-tests-python)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/iamsrinii/dd17fdec-8145-4286-8745-686609200f90/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.